### PR TITLE
Fix Android S+ - API 31 crash

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -88,7 +88,9 @@ dependencies {
 
     // Make sure we're using androidx
     implementation "androidx.core:core:1.3.0-rc01"
-    implementation "androidx.media:media:1.1.0"
+    //GSTAG: Added Fix for Android S+
+    //implementation "androidx.media:media:1.1.0"
+    implementation "androidx.media:media:1.4.1"
     implementation "androidx.localbroadcastmanager:localbroadcastmanager:1.1.0-alpha01"
     implementation "com.github.bumptech.glide:glide:4.7.1"
 }

--- a/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
+++ b/android/src/main/java/com/guichaguri/trackplayer/service/metadata/MetadataManager.java
@@ -81,7 +81,14 @@ public class MetadataManager {
         openApp.setAction(Intent.ACTION_VIEW);
         openApp.setData(Uri.parse("trackplayer://notification.click"));
 
-        builder.setContentIntent(PendingIntent.getActivity(context, 0, openApp, PendingIntent.FLAG_CANCEL_CURRENT));
+        //GSTAG: Added Fix for Android S+
+        //builder.setContentIntent(PendingIntent.getActivity(context, 0, openApp, PendingIntent.FLAG_CANCEL_CURRENT));
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+            builder.setContentIntent(PendingIntent.getActivity(context, 0, openApp, PendingIntent.FLAG_IMMUTABLE));
+        }
+        else {
+            builder.setContentIntent(PendingIntent.getActivity(context, 0, openApp, PendingIntent.FLAG_CANCEL_CURRENT));
+        }
 
         builder.setSmallIcon(R.drawable.play);
         builder.setCategory(NotificationCompat.CATEGORY_TRANSPORT);


### PR DESCRIPTION
Fix for Android API 31 crash as per the instructions [here](https://github.com/doublesymmetry/react-native-track-player/issues/1484#issuecomment-1110812304)